### PR TITLE
fix(auto-join): allow channel passwords in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ $ homura --config /path/to/your_config.json
         {
             "name" : "auto-join",
             "channels" : {
-                "freenode" : [ "#autojoinchan1", "#autojoinchan2" ],
+                "freenode" : [ "#autojoinchan1 passwordchan1", "#autojoinchan2" ],
                 "ircnet"   : [ "#autojoinchan3" ]
             }
         },

--- a/modules/auto-join.js
+++ b/modules/auto-join.js
@@ -10,7 +10,7 @@ AutoJoin.prototype.handleIrcClient = function( ircClient, bouncer ) {
     if (channels) {
         channels.forEach( function(channel) {
             ircClient.on( 'register', (function() {
-                ircClient.send('JOIN', [ channel ]);
+                ircClient.send('JOIN', channel.split(' '));
             }) );
         } );
     }


### PR DESCRIPTION
Simple fix to allow auto-joining password protected channels.
